### PR TITLE
Fix copying of empty lines

### DIFF
--- a/PatchViewer.html
+++ b/PatchViewer.html
@@ -987,6 +987,30 @@
     });
     </script>
 
+    <script>
+        document.addEventListener("copy", (e) => {
+            const selection = window.getSelection();
+            if (!selection.rangeCount) return;
+
+            const range = selection.getRangeAt(0);
+            const selectableCells = Array.from(range.commonAncestorContainer.querySelectorAll("td.selectable, th.selectable"));
+            const selectedCells = selectableCells.filter(cell => range.intersectsNode(cell));
+
+            if (selectedCells.length > 0) {
+                const copiedText = selectedCells.map(
+                    cell => {
+                        const preElement = cell.querySelector("pre");
+                        return preElement && preElement.textContent + "\n";
+                    }
+                ).join("");
+
+                // Override the clipboard content
+                e.clipboardData.setData("text/plain", copiedText);
+                e.preventDefault();
+            }
+        });
+    </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
#5  did not correctly handle empty lines. When copying something like 

 
![image](https://github.com/user-attachments/assets/4c02ebe3-28ac-48f1-b0bd-0270852675cb)

empty lines are omitted. The copied results look like:

```
  // Ray from point to source camera
  const float SX[3] = {src_C[0] - point[0], src_C[1] - point[1], src_C[2] - point[2]};
  // Length of ray from reference image to point.
  const float RX_inv_norm = rsqrt(DotProduct3(RX, RX));
  // Length of ray from source image to point.
  const float SX_inv_norm = rsqrt(DotProduct3(SX, SX));
  *cos_incident_angle = DotProduct3(SX, normal) * SX_inv_norm;
  *cos_triangulation_angle = DotProduct3(RX, SX) * RX_inv_norm * SX_inv_norm;
```


This PR addresses this issue.